### PR TITLE
Refactor menu handling and expose game settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
         <label for="sound">Son :</label>
         <input type="checkbox" id="sound" name="sound" />
         <audio id="menu-music" loop>
-          <source src="AUDIO\bgm.wav" type="audio/wav" />
+          <source src="AUDIO/bgm.wav" type="audio/wav" />
         </audio>
       </div>
 
@@ -172,6 +172,7 @@
     <script src="particles.min.js"></script>
     <script src="particles-configuration.js"></script>
     <script src="language.js"></script>
+    <script src="settings.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/language.js
+++ b/language.js
@@ -11,9 +11,8 @@ let translations = {
     grid: "Grid:",
     none: "None",
     standard: "Standard",
-    partial: "Partial",
     vertical: "Vertical",
-    full: "Full",
+    horizontal: "Horizontal",
     ghost: "Ghost:",
     themeColor: "Theme Color:",
     default: "Default",
@@ -48,9 +47,8 @@ let translations = {
     grid: "Grille :",
     none: "Aucun",
     standard: "Standard",
-    partial: "Partielle",
     vertical: "Verticale",
-    full: "Pleine",
+    horizontal: "Horizontale",
     ghost: "Fantôme :",
     themeColor: "Couleur du thème :",
     default: "Par défaut",
@@ -85,9 +83,8 @@ let translations = {
     grid: "Rejilla:",
     none: "Ninguno",
     standard: "Estándar",
-    partial: "Parcial",
     vertical: "Vertical",
-    full: "Completa",
+    horizontal: "Horizontal",
     ghost: "Fantasma:",
     themeColor: "Color de tema:",
     default: "Por defecto",
@@ -142,6 +139,9 @@ function updateLanguage() {
     translation.instructionsText;
   document.querySelector('label[for="grid"]').textContent = translation.grid;
   document.querySelector('option[value="none"]').textContent = translation.none;
+  document.querySelector('option[value="standard"]').textContent = translation.standard;
+  document.querySelector('option[value="vertical"]').textContent = translation.vertical;
+  document.querySelector('option[value="horizontal"]').textContent = translation.horizontal;
   document.querySelector('label[for="ghost"]').textContent = translation.ghost;
   document.querySelector('label[for="theme-color"]').textContent =
     translation.themeColor;

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,26 @@
+/*jshint esversion: 6 */
+/* jshint browser: true */
+
+window.gameSettings = {
+        grid: "standard",
+        ghost: false,
+        themeColor: "default",
+        blockSpeed: 5,
+        sound: true,
+        visualEffects: true,
+        language: "french",
+};
+
+function applyTheme(color) {
+        const root = document.documentElement;
+        const themes = {
+                default: "#5A65F1",
+                blue: "#1e90ff",
+                red: "#ff4d4d",
+                green: "#2ecc71",
+                purple: "#9b59b6",
+        };
+        root.style.setProperty("--clr", themes[color] || themes.default);
+}
+
+applyTheme(window.gameSettings.themeColor);

--- a/style.css
+++ b/style.css
@@ -202,8 +202,8 @@ body {
 
 #score-frame {
   position: fixed;
-  top: 10px; /* Modifier en fonction des besoins */
-  left: -115px; /* Modifier en fonction des besoins */
+  top: 10px;
+  left: 10px;
   color: var(--secondary-color);
   padding: 20px;
   border-radius: 15px;
@@ -211,8 +211,8 @@ body {
 
 #time-frame {
   position: fixed;
-  top: 10px; /* Modifier en fonction des besoins */
-  right: -123px; /* Modifier en fonction des besoins */
+  top: 10px;
+  right: 10px;
   color: var(--secondary-color);
   padding: 20px;
   border-radius: 15px;


### PR DESCRIPTION
## Summary
- Expose main menu modal globally to prevent reference errors
- Add game restart logic and tie fall speed to user settings
- Align translations and apply selected theme colors
- Clean up debug logs and keep score/time frames visible
- Extract configuration into a separate `settings.js` module

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5d2aa3088322a53cc3333ee17d19