### PR TITLE
refactor: use CSS class for game over modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -118,17 +118,8 @@ function showGameOver() {
 	// Créer une fenêtre modale dynamique
 	const modal = document.createElement('div');
 	modal.id = 'game-over-modal';
-	modal.style.position = 'fixed';
-	modal.style.top = '50%';
-	modal.style.left = '50%';
-	modal.style.transform = 'translate(-50%, -50%)';
-	modal.style.background = 'rgba(0, 0, 0, 0.8)';
-	modal.style.color = 'white';
-	modal.style.padding = '20px';
-	modal.style.borderRadius = '10px';
-	modal.style.textAlign = 'center';
-	modal.style.zIndex = '1000'; // Assurez-vous qu'il apparaît au-dessus de tout
-	// Contenu de la modale
+        modal.classList.add('game-over-modal');
+        // Contenu de la modale
 	modal.innerHTML = `
     <h1>GAME OVER!</h1>
     <p>Score: ${score}</p>

--- a/style.css
+++ b/style.css
@@ -141,6 +141,20 @@ h1, h2 {
     to { transform: rotate(360deg); }
 }
 
+/* Game over modal */
+.game-over-modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0, 0, 0, 0.8);
+    color: white;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+    z-index: 1000;
+}
+
 /* ========================================
    MENU PRINCIPAL
 ======================================== */


### PR DESCRIPTION
## Summary
- add `.game-over-modal` styles for consistent game over dialog
- use `classList` to apply modal styling instead of inline styles

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2aa5ab308322af9577f2eea6ddfa