### PR TITLE
feat: add customizable themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,16 @@
           <option value="red">Rouge</option>
           <option value="green">Vert</option>
           <option value="purple">Violet</option>
+          <option value="custom">Personnalisée</option>
         </select>
+        <div id="custom-theme">
+          <label for="custom-bg">Fond :</label>
+          <input type="color" id="custom-bg" value="#0a0a1a" />
+          <label for="custom-border">Bord :</label>
+          <input type="color" id="custom-border" value="#5A65F1" />
+          <label for="custom-text">Texte :</label>
+          <input type="color" id="custom-text" value="#ffffff" />
+        </div>
       </div>
 
       <div class="option">

--- a/script.js
+++ b/script.js
@@ -435,11 +435,38 @@ document.addEventListener("DOMContentLoaded", () => {
 		.addEventListener("change", function() {
 			gameSettings.grid = this.value;
 		});
-        document.getElementById("theme-color")
-                .addEventListener("change", function() {
-                        gameSettings.themeColor = this.value;
+        const themeSelect = document.getElementById("theme-color");
+        const customThemeContainer = document.getElementById("custom-theme");
+
+        function getCustomTheme() {
+                return {
+                        background: document.getElementById("custom-bg").value,
+                        border: document.getElementById("custom-border").value,
+                        text: document.getElementById("custom-text").value,
+                };
+        }
+
+        themeSelect.addEventListener("change", function() {
+                gameSettings.themeColor = this.value;
+                if (this.value === "custom") {
+                        customThemeContainer.style.display = "block";
+                        gameSettings.customTheme = getCustomTheme();
+                        applyTheme(gameSettings.customTheme);
+                } else {
+                        customThemeContainer.style.display = "none";
                         applyTheme(this.value);
-                });
+                }
+        });
+
+        ["custom-bg", "custom-border", "custom-text"].forEach((id) => {
+                document.getElementById(id)
+                        .addEventListener("input", () => {
+                                if (themeSelect.value === "custom") {
+                                        gameSettings.customTheme = getCustomTheme();
+                                        applyTheme(gameSettings.customTheme);
+                                }
+                        });
+        });
 	// Écouteur d'événements pour mettre à jour la vitesse des blocs
         document.getElementById("block-speed")
                 .addEventListener("change", function() {

--- a/settings.js
+++ b/settings.js
@@ -5,22 +5,54 @@ window.gameSettings = {
         grid: "standard",
         ghost: false,
         themeColor: "default",
+        customTheme: {
+                background: "#0a0a1a",
+                border: "#5A65F1",
+                text: "#ffffff",
+        },
         blockSpeed: 5,
         sound: true,
         visualEffects: true,
         language: "french",
 };
 
-function applyTheme(color) {
+const themes = {
+        default: {
+                background: "#0a0a1a",
+                border: "#5A65F1",
+                text: "#ffffff",
+        },
+        blue: {
+                background: "#001f3f",
+                border: "#1e90ff",
+                text: "#ffffff",
+        },
+        red: {
+                background: "#330000",
+                border: "#ff4d4d",
+                text: "#ffffff",
+        },
+        green: {
+                background: "#001f1a",
+                border: "#2ecc71",
+                text: "#ffffff",
+        },
+        purple: {
+                background: "#2e003e",
+                border: "#9b59b6",
+                text: "#ffffff",
+        },
+};
+
+function applyTheme(theme) {
         const root = document.documentElement;
-        const themes = {
-                default: "#5A65F1",
-                blue: "#1e90ff",
-                red: "#ff4d4d",
-                green: "#2ecc71",
-                purple: "#9b59b6",
-        };
-        root.style.setProperty("--clr", themes[color] || themes.default);
+        const selectedTheme = typeof theme === "string" ? themes[theme] || themes.default : theme;
+        if (!selectedTheme) {
+                return;
+        }
+        root.style.setProperty("--dark-bg", selectedTheme.background);
+        root.style.setProperty("--primary-color", selectedTheme.border);
+        root.style.setProperty("--text-primary", selectedTheme.text);
 }
 
-applyTheme(window.gameSettings.themeColor);
+applyTheme(window.gameSettings.themeColor === "custom" ? window.gameSettings.customTheme : window.gameSettings.themeColor);

--- a/style.css
+++ b/style.css
@@ -358,6 +358,15 @@ h1, h2 {
     cursor: pointer;
 }
 
+#custom-theme {
+    display: none;
+    margin-top: 10px;
+}
+
+#custom-theme label {
+    margin-right: 5px;
+}
+
 /* ========================================
    ANIMATIONS
 ======================================== */


### PR DESCRIPTION
## Summary
- add predefined theme objects and apply background/border/text colors
- support custom user-defined theme colors via options
- update styles and scripts to reflect selected theme immediately

## Testing
- `node --check settings.js`
- `node --check script.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2aaeb66883228068fe9d6f2ad5ba