### PR TITLE
feat: add persistent high scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@
     </div>
 
     <div id="score-container" class="centered-container container">
-      <h1>Score</h1>
-      <p id="score">0</p>
+      <h1 id="score-title">Score</h1>
+      <ol id="score-list"></ol>
       <button class="back-button" id="close-score-button">Retour</button>
     </div>
 
@@ -139,6 +139,10 @@
           <option value="spanish">Espagnol</option>
           <!-- Ajoutez autant d'options de langue que nécessaire -->
         </select>
+      </div>
+
+      <div class="option">
+        <button id="reset-scores">Reset Scores</button>
       </div>
 
       <button class="back-button" id="close-options-button">Retour</button>

--- a/language.js
+++ b/language.js
@@ -24,6 +24,7 @@ let translations = {
     sound: "Sound:",
     visualEffects: "Visual Effects:",
     language: "Language:",
+    resetScores: "Reset Scores",
     french: "French",
     english: "English",
     spanish: "Spanish",
@@ -60,6 +61,7 @@ let translations = {
     sound: "Son :",
     visualEffects: "Effets visuels :",
     language: "Langue :",
+    resetScores: "Réinitialiser les scores",
     french: "Français",
     english: "Anglais",
     spanish: "Espagnol",
@@ -96,6 +98,7 @@ let translations = {
     sound: "Sonido:",
     visualEffects: "Efectos visuales:",
     language: "Idioma:",
+    resetScores: "Restablecer puntuaciones",
     french: "Francés",
     english: "Inglés",
     spanish: "Español",
@@ -131,6 +134,7 @@ function updateLanguage() {
   document
     .getElementById("high-scores-button")
     .setAttribute("aria-label", translation.highScores);
+  document.getElementById("score-title").textContent = translation.highScores;
   document.getElementById("options-button").textContent = translation.options;
   document
     .getElementById("options-button")
@@ -154,6 +158,10 @@ function updateLanguage() {
     translation.visualEffects;
   document.querySelector('label[for="language"]').textContent =
     translation.language;
+  document.getElementById("reset-scores").textContent = translation.resetScores;
+  document
+    .getElementById("reset-scores")
+    .setAttribute("aria-label", translation.resetScores);
 }
 
 document.getElementById("language").addEventListener("change", function () {

--- a/script.js
+++ b/script.js
@@ -6,6 +6,38 @@ let score = 0;
 let lines = 0;
 // Reference globale au conteneur modal
 let modal;
+const SCORE_STORAGE_KEY = 'tetrablock-scores';
+
+function loadScores() {
+        return JSON.parse(localStorage.getItem(SCORE_STORAGE_KEY)) || [];
+}
+
+function saveScore(newScore) {
+        const scores = loadScores();
+        scores.push(newScore);
+        scores.sort((a, b) => b - a);
+        localStorage.setItem(SCORE_STORAGE_KEY, JSON.stringify(scores.slice(0, 5)));
+}
+
+function updateScoreDisplay() {
+        const list = document.getElementById('score-list');
+        if (!list) return;
+        const scores = loadScores();
+        list.innerHTML = '';
+        if (scores.length === 0) {
+                const li = document.createElement('li');
+                li.textContent = '-';
+                list.appendChild(li);
+        }
+        else {
+                scores.forEach((s) => {
+                        const li = document.createElement('li');
+                        li.textContent = s;
+                        list.appendChild(li);
+                });
+        }
+}
+
 // Fonction qui génère un nombre aléatoire entre un minimum et un maximum inclus
 function getRandomInt(min, max) {
 	return Math.floor(Math.random() * (max - min + 1) + min);
@@ -115,6 +147,8 @@ function placeTetromino() {
 function showGameOver() {
 	cancelAnimationFrame(rAF); // Arrêter l'animation
 	gameOver = true;
+        saveScore(score);
+        updateScoreDisplay();
 	// Créer une fenêtre modale dynamique
 	const modal = document.createElement('div');
 	modal.id = 'game-over-modal';
@@ -460,6 +494,7 @@ document.addEventListener("DOMContentLoaded", () => {
         let blockSpeedSelect = document.getElementById("block-speed");
         let gridSelect = document.getElementById("grid");
 	let menu = document.getElementById("menu");
+        updateScoreDisplay();
 	let menuItems = Array.from(menu.getElementsByClassName("menu-item"));
 	let containers = Array.from(document.getElementsByClassName("container"));
 	menuItems.forEach((item) => {
@@ -497,6 +532,11 @@ document.addEventListener("DOMContentLoaded", () => {
 	hideElement("close-score-button", "score-container", "score-started");
 	showElement("options-button", "options-container", "options-started");
 	hideElement("close-options-button", "options-container", "options-started");
+        document.getElementById("high-scores-button").addEventListener("click", updateScoreDisplay);
+        document.getElementById("reset-scores").addEventListener("click", function() {
+                localStorage.removeItem(SCORE_STORAGE_KEY);
+                updateScoreDisplay();
+        });
 	let menuMusic = document.getElementById("menu-music");
 	menuMusic.play();
 	menuMusic.pause();
@@ -526,7 +566,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         function showScores() {
                 closeModal();
-                // Ajoutez ici le code pour afficher les meilleurs scores
+                updateScoreDisplay();
         }
 
         function showOptions() {


### PR DESCRIPTION
## Summary
- persist game scores in localStorage and show them in the high scores screen
- add button in options to reset stored scores
- localize high score labels and reset button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2aab39648322ad69ef9a23c1dc11